### PR TITLE
Fix ESLint errors and development

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "tasks": {
-    "build": "npm install && npm run build",
+    "build": "npm install --legacy-peer-deps && npm run build",
     "launch": "npm install && npm run dev"
   }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,10 +8,25 @@
   ],
   "plugins": ["@typescript-eslint", "react", "jsx-a11y"],
   "rules": {
-    // Add or adjust rules to fix existing ESLint errors
     "react/react-in-jsx-scope": "off",
-    "@typescript-eslint/explicit-function-return-type": "off"
-    // ...other rules as needed
+    "@typescript-eslint/explicit-function-return-type": "off",
+    "react/prop-types": "off",
+    "jsx-a11y/anchor-is-valid": [
+      "error",
+      {
+        "components": ["Link"],
+        "specialLink": ["hrefLeft", "hrefRight"],
+        "aspects": ["invalidHref", "preferButton"]
+      }
+    ],
+    "@typescript-eslint/no-unused-vars": [
+      "error",
+      {
+        "vars": "all",
+        "args": "after-used",
+        "ignoreRestSiblings": false
+      }
+    ]
   },
   "settings": {
     "react": {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,9 @@ jobs:
       - name: Install Dependencies
         run: ${{ steps.detect-package-manager.outputs.manager }} ${{ steps.detect-package-manager.outputs.command }}
 
+      - name: Run ESLint
+        run: ${{ steps.detect-package-manager.outputs.runner }} run lint
+
       - name: Build Next.js Site
         run: ${{ steps.detect-package-manager.outputs.runner }} run build
 

--- a/next.config.js
+++ b/next.config.js
@@ -5,6 +5,9 @@ const nextConfig = {
   images: {
     domains: ['placeholder.com'], // Add your image domains here
   },
+  eslint: {
+    dirs: ['pages', 'components', 'lib', 'hooks', 'models', 'middleware'], // Run ESLint on these directories during build
+  },
   webpack: (config, { isServer }) => {
     if (!isServer) {
       config.resolve.fallback = {


### PR DESCRIPTION
Fix ESLint errors and update development configurations.

* **next.config.js**
  - Add ESLint configuration to run ESLint checks during the build process.

* **.github/workflows/ci.yml**
  - Add a step to run ESLint checks during the build process.

* **.eslintrc.json**
  - Add or adjust rules to fix existing ESLint errors, including rules for `react/prop-types`, `jsx-a11y/anchor-is-valid`, and `@typescript-eslint/no-unused-vars`.

* **.devcontainer/devcontainer.json**
  - Update the build task to use `--legacy-peer-deps` flag during npm install.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/vicharcha/Web/pull/7?shareId=e670d581-db35-4d08-bc43-dd03e967ea8d).