### PR TITLE
Fix unhandled runtime error in auth provider

### DIFF
--- a/app/components/login-form.tsx
+++ b/app/components/login-form.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useState } from "react"
-import { useAuth } from "@/app/components/auth-provider" // Updated import path
+import { useAuth } from "@/lib/auth-provider" // Updated import path
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card"

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -62,26 +62,26 @@ export default function RootLayout({ children }: RootLayoutProps) {
   return (
     <html lang="en" suppressHydrationWarning>
       <body className={inter.className}>
-<ThemeProvider
-  attribute="class"
-  defaultTheme="system"
-  enableSystem
-  disableTransitionOnChange
->
-  <AuthProvider>
-    <div className="relative flex min-h-screen flex-col bg-background">
-      <div className="flex flex-1">
-        <Sidebar />
-        <main className="flex-1 overflow-y-auto">
-          <div className="container mx-auto p-4 pt-16 pb-20 md:pt-4 md:pb-4">
-            {children}
-          </div>
-        </main>
-      </div>
-    </div>
-    <Toaster richColors closeButton position="top-right" />
-  </AuthProvider>
-</ThemeProvider>
+        <ThemeProvider
+          attribute="class"
+          defaultTheme="system"
+          enableSystem
+          disableTransitionOnChange
+        >
+          <AuthProvider>
+            <div className="relative flex min-h-screen flex-col bg-background">
+              <div className="flex flex-1">
+                <Sidebar />
+                <main className="flex-1 overflow-y-auto">
+                  <div className="container mx-auto p-4 pt-16 pb-20 md:pt-4 md:pb-4">
+                    {children}
+                  </div>
+                </main>
+              </div>
+            </div>
+            <Toaster richColors closeButton position="top-right" />
+          </AuthProvider>
+        </ThemeProvider>
       </body>
     </html>
   )

--- a/lib/auth-provider.tsx
+++ b/lib/auth-provider.tsx
@@ -175,4 +175,3 @@ export const useAuth = () => {
   }
   return context
 }
-


### PR DESCRIPTION
Fix the "useAuth must be used within an AuthProvider" error.

* **app/components/login-form.tsx**
  - Update the import path for `useAuth` to use `lib/auth-provider`.

* **app/layout.tsx**
  - Ensure the `AuthProvider` wraps all child components.

* **lib/auth-provider.tsx**
  - Remove unnecessary blank line.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/vicharcha/Web/pull/8?shareId=f57b6368-3d8b-4c47-ace6-88193561c959).