### PR TITLE
Add mockdb backend development

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,16 @@ In development mode (`NODE_ENV=development`):
 - Debug phone number: +911234567890
 - Debug OTP: 123456
 
+## Using the Mock Database
+
+The mock database is used by default in development mode. To enable or disable the mock database, set the `USE_MOCK_DB` environment variable in your `.env` file:
+
+```env
+USE_MOCK_DB=true
+```
+
+When `USE_MOCK_DB` is set to `true`, the application will use the mock database for all operations. This is useful for development and testing purposes.
+
 ## Testing
 
 Run the test suite:

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -19,10 +19,15 @@ if (typeof window === 'undefined') {
 
 let cassandraModule: any = null;
 
+// New function to return the value of useMockDB
+export function useMockDatabase(): boolean {
+  return useMockDB;
+}
+
 // Basic database operations
 export async function executeQuery(query: string, params: any[]): Promise<DatabaseResult> {
   // Always use mock DB in development when configured
-  if (useMockDB) {
+  if (useMockDatabase()) {
     console.log('Using mock database');
     return mockDB.query(query, params);
   }


### PR DESCRIPTION
Add a new function `useMockDatabase` to return the value of `useMockDB` and update the `executeQuery` function to use `useMockDatabase` instead of `useMockDB` directly.

* **lib/db.ts**
  - Add a new function `useMockDatabase` to return the value of `useMockDB`.
  - Update the `executeQuery` function to use `useMockDatabase` instead of `useMockDB` directly.

* **README.md**
  - Add a section explaining the use of the mock database in development mode.
  - Add instructions for setting the `USE_MOCK_DB` environment variable.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/vicharcha/Web/pull/23?shareId=666d987a-b4c7-493b-ad42-b138a823ba8f).